### PR TITLE
  Separating Queries & Side-effects for Simplicity and Reusability, Choosing Between Enum Switching Strategies, and Differentiating App-Specific from App-Agnostic Logic

### DIFF
--- a/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		AC2E622D2A62184900456F6D /* LoadFeedFromCacheUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2E622C2A62184900456F6D /* LoadFeedFromCacheUseCaseTests.swift */; };
 		AC2E62302A62198100456F6D /* FeedStoreSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2E622F2A62198100456F6D /* FeedStoreSpy.swift */; };
 		AC3F86A02A708D6F00BA8497 /* ValidateFeedCacheUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC3F869F2A708D6F00BA8497 /* ValidateFeedCacheUseCaseTests.swift */; };
+		AC3F86A22A70911E00BA8497 /* FeedCacheTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC3F86A12A70911E00BA8497 /* FeedCacheTestHelpers.swift */; };
+		AC3F86A42A7091F100BA8497 /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC3F86A32A7091F100BA8497 /* SharedTestHelpers.swift */; };
 		AC5327282A3A9E1400C127BB /* URLSessionHTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC5327272A3A9E1400C127BB /* URLSessionHTTPClient.swift */; };
 		AC5327302A3B859300C127BB /* EssentialFeedAPIEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC53272F2A3B859300C127BB /* EssentialFeedAPIEndToEndTests.swift */; };
 		AC5327312A3B859300C127BB /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC8A425A2A295E4200D1CC84 /* EssentialFeed.framework */; };
@@ -59,6 +61,8 @@
 		AC2E622C2A62184900456F6D /* LoadFeedFromCacheUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadFeedFromCacheUseCaseTests.swift; sourceTree = "<group>"; };
 		AC2E622F2A62198100456F6D /* FeedStoreSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedStoreSpy.swift; sourceTree = "<group>"; };
 		AC3F869F2A708D6F00BA8497 /* ValidateFeedCacheUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidateFeedCacheUseCaseTests.swift; sourceTree = "<group>"; };
+		AC3F86A12A70911E00BA8497 /* FeedCacheTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCacheTestHelpers.swift; sourceTree = "<group>"; };
+		AC3F86A32A7091F100BA8497 /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
 		AC5327272A3A9E1400C127BB /* URLSessionHTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionHTTPClient.swift; sourceTree = "<group>"; };
 		AC53272D2A3B859300C127BB /* EssentialFeedAPIEndToEndTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialFeedAPIEndToEndTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC53272F2A3B859300C127BB /* EssentialFeedAPIEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EssentialFeedAPIEndToEndTests.swift; sourceTree = "<group>"; };
@@ -131,6 +135,7 @@
 			isa = PBXGroup;
 			children = (
 				AC2E622F2A62198100456F6D /* FeedStoreSpy.swift */,
+				AC3F86A12A70911E00BA8497 /* FeedCacheTestHelpers.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -211,6 +216,7 @@
 			isa = PBXGroup;
 			children = (
 				ACE5CB4D2A3A888500F1A788 /* XCTTestCase+MemoryTrackingHelper.swift */,
+				AC3F86A32A7091F100BA8497 /* SharedTestHelpers.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -392,10 +398,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AC3F86A22A70911E00BA8497 /* FeedCacheTestHelpers.swift in Sources */,
 				AC3F86A02A708D6F00BA8497 /* ValidateFeedCacheUseCaseTests.swift in Sources */,
 				AC8A42802A29B0AA00D1CC84 /* LoadFeedFromRemoteUseCaseTests.swift in Sources */,
 				ACE5CB4E2A3A888500F1A788 /* XCTTestCase+MemoryTrackingHelper.swift in Sources */,
 				AC2E62302A62198100456F6D /* FeedStoreSpy.swift in Sources */,
+				AC3F86A42A7091F100BA8497 /* SharedTestHelpers.swift in Sources */,
 				AC2E62232A4CC73900456F6D /* CacheFeedUseCaseTests.swift in Sources */,
 				AC2E622D2A62184900456F6D /* LoadFeedFromCacheUseCaseTests.swift in Sources */,
 				AC7770CD2A39071B00D5D73F /* URLSessionHTTPClientTests.swift in Sources */,

--- a/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		AC2E622B2A61E4C300456F6D /* LocalFeedImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2E622A2A61E4C300456F6D /* LocalFeedImage.swift */; };
 		AC2E622D2A62184900456F6D /* LoadFeedFromCacheUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2E622C2A62184900456F6D /* LoadFeedFromCacheUseCaseTests.swift */; };
 		AC2E62302A62198100456F6D /* FeedStoreSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2E622F2A62198100456F6D /* FeedStoreSpy.swift */; };
+		AC3F86A02A708D6F00BA8497 /* ValidateFeedCacheUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC3F869F2A708D6F00BA8497 /* ValidateFeedCacheUseCaseTests.swift */; };
 		AC5327282A3A9E1400C127BB /* URLSessionHTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC5327272A3A9E1400C127BB /* URLSessionHTTPClient.swift */; };
 		AC5327302A3B859300C127BB /* EssentialFeedAPIEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC53272F2A3B859300C127BB /* EssentialFeedAPIEndToEndTests.swift */; };
 		AC5327312A3B859300C127BB /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC8A425A2A295E4200D1CC84 /* EssentialFeed.framework */; };
@@ -57,6 +58,7 @@
 		AC2E622A2A61E4C300456F6D /* LocalFeedImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFeedImage.swift; sourceTree = "<group>"; };
 		AC2E622C2A62184900456F6D /* LoadFeedFromCacheUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadFeedFromCacheUseCaseTests.swift; sourceTree = "<group>"; };
 		AC2E622F2A62198100456F6D /* FeedStoreSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedStoreSpy.swift; sourceTree = "<group>"; };
+		AC3F869F2A708D6F00BA8497 /* ValidateFeedCacheUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidateFeedCacheUseCaseTests.swift; sourceTree = "<group>"; };
 		AC5327272A3A9E1400C127BB /* URLSessionHTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionHTTPClient.swift; sourceTree = "<group>"; };
 		AC53272D2A3B859300C127BB /* EssentialFeedAPIEndToEndTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialFeedAPIEndToEndTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC53272F2A3B859300C127BB /* EssentialFeedAPIEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EssentialFeedAPIEndToEndTests.swift; sourceTree = "<group>"; };
@@ -120,6 +122,7 @@
 				AC2E622E2A62196F00456F6D /* Helpers */,
 				AC2E62222A4CC73900456F6D /* CacheFeedUseCaseTests.swift */,
 				AC2E622C2A62184900456F6D /* LoadFeedFromCacheUseCaseTests.swift */,
+				AC3F869F2A708D6F00BA8497 /* ValidateFeedCacheUseCaseTests.swift */,
 			);
 			path = "Feed Cache";
 			sourceTree = "<group>";
@@ -389,6 +392,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AC3F86A02A708D6F00BA8497 /* ValidateFeedCacheUseCaseTests.swift in Sources */,
 				AC8A42802A29B0AA00D1CC84 /* LoadFeedFromRemoteUseCaseTests.swift in Sources */,
 				ACE5CB4E2A3A888500F1A788 /* XCTTestCase+MemoryTrackingHelper.swift in Sources */,
 				AC2E62302A62198100456F6D /* FeedStoreSpy.swift in Sources */,

--- a/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -49,7 +49,7 @@ extension LocalFeedLoader {
     }
 }
 
-extension LocalFeedLoader {
+extension LocalFeedLoader: FeedLoader {
     public func load(completion: @escaping (LoadResult) -> Void) {
         store.retrieve { [weak self] result in
             guard let self = self else { return }

--- a/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -7,9 +7,6 @@ public final class LocalFeedLoader {
     private let currentDate: () -> Date
     private let calendar = Calendar(identifier: .gregorian)
     
-    public typealias SaveResult = Error?
-    public typealias LoadResult = LoadFeedResult
-    
     public init(store: FeedStore, currentDate: @escaping () -> Date) {
         self.store = store
         self.currentDate = currentDate
@@ -28,6 +25,8 @@ public final class LocalFeedLoader {
 }
 
 extension LocalFeedLoader {
+    public typealias SaveResult = Error?
+
     public func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> ()) {
         store.deleteCachedFeed() { [weak self] error in
             guard let self = self else { return }
@@ -50,6 +49,8 @@ extension LocalFeedLoader {
 }
 
 extension LocalFeedLoader: FeedLoader {
+    public typealias LoadResult = LoadFeedResult
+
     public func load(completion: @escaping (LoadResult) -> Void) {
         store.retrieve { [weak self] result in
             guard let self = self else { return }

--- a/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -32,7 +32,6 @@ public final class LocalFeedLoader {
             guard let self = self else { return }
             switch result {
             case let .failure(error):
-                self.store.deleteCachedFeed { _ in  }
                 completion(.failure(error))
                  
             case let .found(feed, timestamp) where self.validate(timestamp):
@@ -46,6 +45,11 @@ public final class LocalFeedLoader {
                 completion(.success([]))
             }
         }
+    }
+    
+    public func validateCache() {
+        store.retrieve { _ in }
+        store.deleteCachedFeed { _ in }
     }
     
     private var maxCacheAgeInDays: Int {

--- a/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -38,7 +38,6 @@ public final class LocalFeedLoader {
                 completion(.success(feed.toModels()))
                 
             case .found:
-                self.store.deleteCachedFeed { _ in  }
                 completion(.success([]))
 
             case .empty:
@@ -52,7 +51,11 @@ public final class LocalFeedLoader {
             switch result {
             case .failure:
                 self.store.deleteCachedFeed { _ in }
-            default: break
+                
+            case let .found(_, timestamp) where !self.validate(timestamp):
+                self.store.deleteCachedFeed { _ in }
+
+            case .empty, .found: break
             }
         }
     }

--- a/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -47,7 +47,8 @@ public final class LocalFeedLoader {
     }
     
     public func validateCache() {
-        store.retrieve { [unowned self] result in
+        store.retrieve { [weak self] result in
+            guard let self = self else { return }
             switch result {
             case .failure:
                 self.store.deleteCachedFeed { _ in }

--- a/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -48,8 +48,13 @@ public final class LocalFeedLoader {
     }
     
     public func validateCache() {
-        store.retrieve { _ in }
-        store.deleteCachedFeed { _ in }
+        store.retrieve { [unowned self] result in
+            switch result {
+            case .failure:
+                self.store.deleteCachedFeed { _ in }
+            default: break
+            }
+        }
     }
     
     private var maxCacheAgeInDays: Int {

--- a/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -37,10 +37,7 @@ public final class LocalFeedLoader {
             case let .found(feed, timestamp) where self.validate(timestamp):
                 completion(.success(feed.toModels()))
                 
-            case .found:
-                completion(.success([]))
-
-            case .empty:
+            case .empty, .found:                
                 completion(.success([]))
             }
         }

--- a/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -6,56 +6,13 @@ public final class LocalFeedLoader {
     private let store: FeedStore
     private let currentDate: () -> Date
     private let calendar = Calendar(identifier: .gregorian)
-
+    
     public typealias SaveResult = Error?
     public typealias LoadResult = LoadFeedResult
     
     public init(store: FeedStore, currentDate: @escaping () -> Date) {
         self.store = store
         self.currentDate = currentDate
-    }
-    
-    public func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> ()) {
-        store.deleteCachedFeed() { [weak self] error in
-            guard let self = self else { return }
-            
-            if let cacheDeletionError = error {
-                completion(cacheDeletionError)
-            } else {
-                self.cache(feed: feed, with: completion)
-            }
-        }
-    }
-    
-    public func load(completion: @escaping (LoadResult) -> Void) {
-        store.retrieve { [weak self] result in
-            guard let self = self else { return }
-            switch result {
-            case let .failure(error):
-                completion(.failure(error))
-                 
-            case let .found(feed, timestamp) where self.validate(timestamp):
-                completion(.success(feed.toModels()))
-                
-            case .empty, .found:                
-                completion(.success([]))
-            }
-        }
-    }
-    
-    public func validateCache() {
-        store.retrieve { [weak self] result in
-            guard let self = self else { return }
-            switch result {
-            case .failure:
-                self.store.deleteCachedFeed { _ in }
-                
-            case let .found(_, timestamp) where !self.validate(timestamp):
-                self.store.deleteCachedFeed { _ in }
-
-            case .empty, .found: break
-            }
-        }
     }
     
     private var maxCacheAgeInDays: Int {
@@ -68,6 +25,20 @@ public final class LocalFeedLoader {
         }
         return currentDate() < maxCacheAge
     }
+}
+
+extension LocalFeedLoader {
+    public func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> ()) {
+        store.deleteCachedFeed() { [weak self] error in
+            guard let self = self else { return }
+            
+            if let cacheDeletionError = error {
+                completion(cacheDeletionError)
+            } else {
+                self.cache(feed: feed, with: completion)
+            }
+        }
+    }
     
     private func cache(feed: [FeedImage], with completion: @escaping (SaveResult) -> ()) {
         self.store.insert(feed.toLocal(), timestamp: self.currentDate()) { [weak self] error in
@@ -77,6 +48,42 @@ public final class LocalFeedLoader {
         }
     }
 }
+
+extension LocalFeedLoader {
+    public func load(completion: @escaping (LoadResult) -> Void) {
+        store.retrieve { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case let .failure(error):
+                completion(.failure(error))
+                
+            case let .found(feed, timestamp) where self.validate(timestamp):
+                completion(.success(feed.toModels()))
+                
+            case .empty, .found:
+                completion(.success([]))
+            }
+        }
+    }
+}
+
+extension LocalFeedLoader {
+    public func validateCache() {
+        store.retrieve { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .failure:
+                self.store.deleteCachedFeed { _ in }
+                
+            case let .found(_, timestamp) where !self.validate(timestamp):
+                self.store.deleteCachedFeed { _ in }
+                
+            case .empty, .found: break
+            }
+        }
+    }
+}
+
 
 private extension Array where Element == FeedImage {
     func toLocal() -> [LocalFeedImage] {

--- a/EssentialFeedTests/Feed API/URLSessionHTTPClientTests.swift
+++ b/EssentialFeedTests/Feed API/URLSessionHTTPClientTests.swift
@@ -124,16 +124,8 @@ final class URLSessionHTTPClientTests: XCTestCase {
         return receivedResult!
     }
     
-    private func anyURL() -> URL {
-        return URL(string: "http://any-url.com")!
-    }
-    
     private func anyData() -> Data {
         Data("any data".utf8)
-    }
-    
-    private func anyNSError() -> NSError {
-        NSError(domain: "any error", code: 1)
     }
     
     private func nonHTTPURLResponse() -> URLResponse {

--- a/EssentialFeedTests/Feed Cache/CacheFeedUseCaseTests.swift
+++ b/EssentialFeedTests/Feed Cache/CacheFeedUseCaseTests.swift
@@ -125,29 +125,5 @@ final class CacheFeedUseCaseTests: XCTestCase {
         
         XCTAssertEqual(receivedError as? NSError, expectedError, file: file, line: line)
     }
-    
-    private func uniqueImage() -> FeedImage {
-        FeedImage(
-            id: UUID(),
-            description: "any",
-            location: "any",
-            url: anyURL()
-        )
-    }
-    
-    private func uniqueImageFeed() -> (models: [FeedImage], local: [LocalFeedImage]) {
-        let models = [uniqueImage(), uniqueImage()]
-        let local = models.map { LocalFeedImage(id: $0.id, description: $0.description, location: $0.location, url: $0.url) }
-        return (models, local)
-    }
-    
-    private func anyURL() -> URL {
-        return URL(string: "http://any-url.com")!
-    }
-    
-    private func anyNSError() -> NSError {
-        NSError(domain: "any error", code: 1)
-    }
-    
 }
 

--- a/EssentialFeedTests/Feed Cache/Helpers/FeedCacheTestHelpers.swift
+++ b/EssentialFeedTests/Feed Cache/Helpers/FeedCacheTestHelpers.swift
@@ -1,0 +1,29 @@
+//  Created by Wiiliam Peregoy on 7/25/23
+
+import Foundation
+import EssentialFeed
+
+func uniqueImage() -> FeedImage {
+    FeedImage(
+        id: UUID(),
+        description: "any",
+        location: "any",
+        url: anyURL()
+    )
+}
+
+func uniqueImageFeed() -> (models: [FeedImage], local: [LocalFeedImage]) {
+    let models = [uniqueImage(), uniqueImage()]
+    let local = models.map { LocalFeedImage(id: $0.id, description: $0.description, location: $0.location, url: $0.url) }
+    return (models, local)
+}
+
+extension Date {
+    func adding(days: Int) -> Date {
+        return Calendar(identifier: .gregorian).date(byAdding: .init(day: days), to: self)!
+    }
+    
+    func adding(seconds: TimeInterval) -> Date {
+        return self + seconds
+    }
+}

--- a/EssentialFeedTests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
+++ b/EssentialFeedTests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
@@ -4,7 +4,7 @@ import XCTest
 import EssentialFeed
 
 final class LoadFeedFromCacheUseCaseTests: XCTestCase {
-
+    
     func test_init_doesNotMessageStoreUponCreation() {
         let (_, store) = makeSUT()
         XCTAssertEqual(store.receivedMessages, [])
@@ -69,7 +69,7 @@ final class LoadFeedFromCacheUseCaseTests: XCTestCase {
     }
     
     func test_load_hasNoSideEffectsOnRetrievalError() {
-         let (sut, store) = makeSUT()
+        let (sut, store) = makeSUT()
         
         sut.load { _ in }
         store.completeRetrieval(with: anyNSError())
@@ -78,7 +78,7 @@ final class LoadFeedFromCacheUseCaseTests: XCTestCase {
     }
     
     func test_load_hasNoSideEffectsOnEmptyCache() {
-         let (sut, store) = makeSUT()
+        let (sut, store) = makeSUT()
         
         sut.load { _ in }
         store.completeRetrievalWithEmptyCache()
@@ -136,7 +136,7 @@ final class LoadFeedFromCacheUseCaseTests: XCTestCase {
     }
     
     // MARK: - Helpers
-     
+    
     private func makeSUT(currentDate: @escaping () -> Date = Date.init,
                          file: StaticString = #filePath,
                          line: UInt = #line) -> (sut: LocalFeedLoader, store: FeedStoreSpy) {
@@ -153,7 +153,7 @@ final class LoadFeedFromCacheUseCaseTests: XCTestCase {
                         file: StaticString = #filePath,
                         line: UInt = #line) {
         let exp = expectation(description: "Wait for load.")
-
+        
         sut.load { receivedResult in
             switch (receivedResult, expectedResult) {
             case let (.success(receivedImages), .success(expectedImages)):
@@ -161,48 +161,15 @@ final class LoadFeedFromCacheUseCaseTests: XCTestCase {
                 
             case let (.failure(receivedError as NSError), .failure(expectedError as NSError)):
                 XCTAssertEqual(receivedError, expectedError, file: file, line: line)
-
+                
             default:
                 XCTFail("Expected result \(expectedResult), got \(receivedResult) instead")
             }
             exp.fulfill()
         }
-
+        
         action()
         wait(for: [exp], timeout: 1.0)
     }
     
-    private func anyNSError() -> NSError {
-        NSError(domain: "any error", code: 1)
-    }
-    
-    private func anyURL() -> URL {
-        return URL(string: "http://any-url.com")!
-    }
-    
-    private func uniqueImage() -> FeedImage {
-        FeedImage(
-            id: UUID(),
-            description: "any",
-            location: "any",
-            url: anyURL()
-        )
-    }
-    
-    private func uniqueImageFeed() -> (models: [FeedImage], local: [LocalFeedImage]) {
-        let models = [uniqueImage(), uniqueImage()]
-        let local = models.map { LocalFeedImage(id: $0.id, description: $0.description, location: $0.location, url: $0.url) }
-        return (models, local)
-    }
-    
-}
-
-private extension Date {
-    func adding(days: Int) -> Date {
-        return Calendar(identifier: .gregorian).date(byAdding: .init(day: days), to: self)!
-    }
-    
-    func adding(seconds: TimeInterval) -> Date {
-        return self + seconds
-    }
-}
+} 

--- a/EssentialFeedTests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
+++ b/EssentialFeedTests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
@@ -68,13 +68,13 @@ final class LoadFeedFromCacheUseCaseTests: XCTestCase {
         }
     }
     
-    func test_load_deletesCacheOnRetrievalError() {
+    func test_load_hasNoSideEffectsOnRetrievalError() {
          let (sut, store) = makeSUT()
         
         sut.load { _ in }
         store.completeRetrieval(with: anyNSError())
         
-        XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
+        XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
     
     func test_load_doesNotDeleteCacheOnEmptyCache() {

--- a/EssentialFeedTests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
+++ b/EssentialFeedTests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
@@ -77,7 +77,7 @@ final class LoadFeedFromCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
     
-    func test_load_doesNotDeleteCacheOnEmptyCache() {
+    func test_load_hasNoSideEffectsOnEmptyCache() {
          let (sut, store) = makeSUT()
         
         sut.load { _ in }

--- a/EssentialFeedTests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
+++ b/EssentialFeedTests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
@@ -98,7 +98,7 @@ final class LoadFeedFromCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
     
-    func test_load_doesDeleteCacheOnSevenDaysOldCache() {
+    func test_load_hasNoSideEffectsOnSevenDaysOldCache() {
         let feed = uniqueImageFeed()
         let fixedCurrentDate = Date()
         let sevenDaysOldTimestamp = fixedCurrentDate.adding(days: -7)
@@ -107,10 +107,10 @@ final class LoadFeedFromCacheUseCaseTests: XCTestCase {
         sut.load { _ in }
         store.completeRetrieval(with: feed.local, timestamp: sevenDaysOldTimestamp )
         
-        XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
+        XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
     
-    func test_load_doesDeleteCacheOnMoreThanSevenDaysOldCache() {
+    func test_load_hasNoSideEffectsOnMoreThanSevenDaysOldCache() {
         let feed = uniqueImageFeed()
         let fixedCurrentDate = Date()
         let moreThanSevenDaysOldTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: -1)
@@ -119,7 +119,7 @@ final class LoadFeedFromCacheUseCaseTests: XCTestCase {
         sut.load { _ in }
         store.completeRetrieval(with: feed.local, timestamp: moreThanSevenDaysOldTimestamp )
         
-        XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
+        XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
     
     func test_load_doesNotDeliverResultAfterSUTInstanceHasBeenDeallocated() {

--- a/EssentialFeedTests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
+++ b/EssentialFeedTests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
@@ -86,7 +86,7 @@ final class LoadFeedFromCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
     
-    func test_load_doesNotDeleteCacheOnLessThanSevenDaysOldCache() {
+    func test_load_hasNoSideEffectsOnLessThanSevenDaysOldCache() {
         let feed = uniqueImageFeed()
         let fixedCurrentDate = Date()
         let lessThanSevenDaysOldTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: 1)

--- a/EssentialFeedTests/Feed Cache/ValidateFeedCacheUseCaseTests.swift
+++ b/EssentialFeedTests/Feed Cache/ValidateFeedCacheUseCaseTests.swift
@@ -19,7 +19,16 @@ final class ValidateFeedCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
     }
     
-    // MARK: - Helpers
+    func test_validateCache_doesNotDeleteCacheOnEmptyCache() {
+         let (sut, store) = makeSUT()
+        
+        sut.validateCache()
+        store.completeRetrievalWithEmptyCache()
+        
+        XCTAssertEqual(store.receivedMessages, [.retrieve])
+    }
+    
+    // MARK: - Helpersx
      
     private func makeSUT(currentDate: @escaping () -> Date = Date.init,
                          file: StaticString = #filePath,

--- a/EssentialFeedTests/Feed Cache/ValidateFeedCacheUseCaseTests.swift
+++ b/EssentialFeedTests/Feed Cache/ValidateFeedCacheUseCaseTests.swift
@@ -28,6 +28,18 @@ final class ValidateFeedCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
     
+    func test_validateCache_doesNotDeleteCacheOnLessThanSevenDaysOldCache() {
+        let feed = uniqueImageFeed()
+        let fixedCurrentDate = Date()
+        let lessThanSevenDaysOldTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: 1)
+        let (sut, store) = makeSUT { fixedCurrentDate }
+        
+        sut.validateCache()
+        store.completeRetrieval(with: feed.local, timestamp: lessThanSevenDaysOldTimestamp)
+        
+        XCTAssertEqual(store.receivedMessages, [.retrieve])
+    }
+    
     // MARK: - Helpersx
      
     private func makeSUT(currentDate: @escaping () -> Date = Date.init,
@@ -44,5 +56,33 @@ final class ValidateFeedCacheUseCaseTests: XCTestCase {
         NSError(domain: "any error", code: 1)
     }
     
+    private func anyURL() -> URL {
+        return URL(string: "http://any-url.com")!
+    }
+    
+    private func uniqueImage() -> FeedImage {
+        FeedImage(
+            id: UUID(),
+            description: "any",
+            location: "any",
+            url: anyURL()
+        )
+    }
+    
+    private func uniqueImageFeed() -> (models: [FeedImage], local: [LocalFeedImage]) {
+        let models = [uniqueImage(), uniqueImage()]
+        let local = models.map { LocalFeedImage(id: $0.id, description: $0.description, location: $0.location, url: $0.url) }
+        return (models, local)
+    }
 }
 
+
+private extension Date {
+    func adding(days: Int) -> Date {
+        return Calendar(identifier: .gregorian).date(byAdding: .init(day: days), to: self)!
+    }
+    
+    func adding(seconds: TimeInterval) -> Date {
+        return self + seconds
+    }
+}

--- a/EssentialFeedTests/Feed Cache/ValidateFeedCacheUseCaseTests.swift
+++ b/EssentialFeedTests/Feed Cache/ValidateFeedCacheUseCaseTests.swift
@@ -10,6 +10,15 @@ final class ValidateFeedCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(store.receivedMessages, [])
     }
     
+    func test_validateCache_deletesCacheOnRetrievalError() {
+         let (sut, store) = makeSUT()
+        
+        sut.validateCache()
+        store.completeRetrieval(with: anyNSError())
+        
+        XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
+    }
+    
     // MARK: - Helpers
      
     private func makeSUT(currentDate: @escaping () -> Date = Date.init,
@@ -21,4 +30,10 @@ final class ValidateFeedCacheUseCaseTests: XCTestCase {
         trackForMemoryLeaks(store, file: file, line: line)
         return (sut, store)
     }
+    
+    private func anyNSError() -> NSError {
+        NSError(domain: "any error", code: 1)
+    }
+    
 }
+

--- a/EssentialFeedTests/Feed Cache/ValidateFeedCacheUseCaseTests.swift
+++ b/EssentialFeedTests/Feed Cache/ValidateFeedCacheUseCaseTests.swift
@@ -1,0 +1,24 @@
+//  Created by Wiiliam Peregoy on 7/25/23
+
+import XCTest
+import EssentialFeed
+
+final class ValidateFeedCacheUseCaseTests: XCTestCase {
+
+    func test_init_doesNotMessageStoreUponCreation() {
+        let (_, store) = makeSUT()
+        XCTAssertEqual(store.receivedMessages, [])
+    }
+    
+    // MARK: - Helpers
+     
+    private func makeSUT(currentDate: @escaping () -> Date = Date.init,
+                         file: StaticString = #filePath,
+                         line: UInt = #line) -> (sut: LocalFeedLoader, store: FeedStoreSpy) {
+        let store = FeedStoreSpy()
+        let sut = LocalFeedLoader(store: store, currentDate: currentDate)
+        trackForMemoryLeaks(sut, file: file, line: line)
+        trackForMemoryLeaks(store, file: file, line: line)
+        return (sut, store)
+    }
+}

--- a/EssentialFeedTests/Feed Cache/ValidateFeedCacheUseCaseTests.swift
+++ b/EssentialFeedTests/Feed Cache/ValidateFeedCacheUseCaseTests.swift
@@ -4,14 +4,14 @@ import XCTest
 import EssentialFeed
 
 final class ValidateFeedCacheUseCaseTests: XCTestCase {
-
+    
     func test_init_doesNotMessageStoreUponCreation() {
         let (_, store) = makeSUT()
         XCTAssertEqual(store.receivedMessages, [])
     }
     
     func test_validateCache_deletesCacheOnRetrievalError() {
-         let (sut, store) = makeSUT()
+        let (sut, store) = makeSUT()
         
         sut.validateCache()
         store.completeRetrieval(with: anyNSError())
@@ -20,7 +20,7 @@ final class ValidateFeedCacheUseCaseTests: XCTestCase {
     }
     
     func test_validateCache_doesNotDeleteCacheOnEmptyCache() {
-         let (sut, store) = makeSUT()
+        let (sut, store) = makeSUT()
         
         sut.validateCache()
         store.completeRetrievalWithEmptyCache()
@@ -40,8 +40,8 @@ final class ValidateFeedCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
     
-    // MARK: - Helpersx
-     
+    // MARK: - Helpers
+    
     private func makeSUT(currentDate: @escaping () -> Date = Date.init,
                          file: StaticString = #filePath,
                          line: UInt = #line) -> (sut: LocalFeedLoader, store: FeedStoreSpy) {
@@ -50,39 +50,5 @@ final class ValidateFeedCacheUseCaseTests: XCTestCase {
         trackForMemoryLeaks(sut, file: file, line: line)
         trackForMemoryLeaks(store, file: file, line: line)
         return (sut, store)
-    }
-    
-    private func anyNSError() -> NSError {
-        NSError(domain: "any error", code: 1)
-    }
-    
-    private func anyURL() -> URL {
-        return URL(string: "http://any-url.com")!
-    }
-    
-    private func uniqueImage() -> FeedImage {
-        FeedImage(
-            id: UUID(),
-            description: "any",
-            location: "any",
-            url: anyURL()
-        )
-    }
-    
-    private func uniqueImageFeed() -> (models: [FeedImage], local: [LocalFeedImage]) {
-        let models = [uniqueImage(), uniqueImage()]
-        let local = models.map { LocalFeedImage(id: $0.id, description: $0.description, location: $0.location, url: $0.url) }
-        return (models, local)
-    }
-}
-
-
-private extension Date {
-    func adding(days: Int) -> Date {
-        return Calendar(identifier: .gregorian).date(byAdding: .init(day: days), to: self)!
-    }
-    
-    func adding(seconds: TimeInterval) -> Date {
-        return self + seconds
     }
 }

--- a/EssentialFeedTests/Feed Cache/ValidateFeedCacheUseCaseTests.swift
+++ b/EssentialFeedTests/Feed Cache/ValidateFeedCacheUseCaseTests.swift
@@ -40,6 +40,30 @@ final class ValidateFeedCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
     
+    func test_validateCache_deleteCacheOnSevenDaysOldCache() {
+        let feed = uniqueImageFeed()
+        let fixedCurrentDate = Date()
+        let sevenDaysOldTimestamp = fixedCurrentDate.adding(days: -7)
+        let (sut, store) = makeSUT { fixedCurrentDate }
+        
+        sut.validateCache()
+        store.completeRetrieval(with: feed.local, timestamp: sevenDaysOldTimestamp )
+        
+        XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
+    }
+    
+    func test_validateCache_deleteCacheOnMoreThanSevenDaysOldCache() {
+        let feed = uniqueImageFeed()
+        let fixedCurrentDate = Date()
+        let moreThanSevenDaysOldTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: -1)
+        let (sut, store) = makeSUT { fixedCurrentDate }
+        
+        sut.validateCache()
+        store.completeRetrieval(with: feed.local, timestamp: moreThanSevenDaysOldTimestamp )
+        
+        XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
+    }
+    
     // MARK: - Helpers
     
     private func makeSUT(currentDate: @escaping () -> Date = Date.init,

--- a/EssentialFeedTests/Feed Cache/ValidateFeedCacheUseCaseTests.swift
+++ b/EssentialFeedTests/Feed Cache/ValidateFeedCacheUseCaseTests.swift
@@ -64,6 +64,19 @@ final class ValidateFeedCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
     }
     
+    func test_validateCache_doesNotDeleteInvalidCacheAfterSUTInstanceHasBeenDeallocated() {
+        let store = FeedStoreSpy()
+        var sut: LocalFeedLoader? = LocalFeedLoader(store: store, currentDate: Date.init)
+        
+        sut?.validateCache()
+        
+        sut = nil
+        store.completeRetrieval(with: anyNSError())
+        
+        XCTAssertEqual(store.receivedMessages, [.retrieve])
+    }
+    
+    
     // MARK: - Helpers
     
     private func makeSUT(currentDate: @escaping () -> Date = Date.init,

--- a/EssentialFeedTests/Helpers/SharedTestHelpers.swift
+++ b/EssentialFeedTests/Helpers/SharedTestHelpers.swift
@@ -1,0 +1,12 @@
+//  Created by Wiiliam Peregoy on 7/25/23
+
+import Foundation
+
+func anyNSError() -> NSError {
+    NSError(domain: "any error", code: 1)
+}
+
+func anyURL() -> URL {
+    return URL(string: "http://any-url.com")!
+}
+

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Given the customer doesn't have connectivity
 5. System delivers image feed.
 
 #### Retrieval Error course (sad path):
-2. System delivers error.
+  2. System delivers error.
 
 #### Expired cache course (sad path): 
 2. System delivers empty image feed.

--- a/README.md
+++ b/README.md
@@ -84,16 +84,29 @@ Given the customer doesn't have connectivity
 5. System delivers image feed.
 
 #### Retrieval Error course (sad path):
-1. System deletes cache.
 2. System delivers error.
 
 #### Expired cache course (sad path): 
-1. System deletes cache.
 2. System delivers empty image feed.
 
 #### Empty cache course (sad path): 
 1. System delivers empty image feed.
 
+### Validate Feed Cache Use Case
+
+#### Primary course:
+1. Execute "Validate Cache" command with above data.
+2. System fetches image feed data from cache.
+3. System validates cache is less than seven days old.
+
+#### Retrieval Error course (sad path):
+1. System deletes cache.
+
+#### Expired cache course (sad path): 
+1. System deletes cache.
+
+#### Empty cache course (sad path): 
+1. System delivers empty image feed
 
 ### Cache Feed Use Case
 


### PR DESCRIPTION
Separating Queries & Side-effects for Simplicity and Reusability, Choosing Between Enum Switching Strategies, and Differentiating App-Specific from App-Agnostic Logic