### PR TITLE
  Apple MVC, Test-driving UIViewControllers, Dealing with UIKit’s Inversion of Control & Temporal Coupling, and Decoupling Tests from UI Implementation Details

### DIFF
--- a/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		AC8A42802A29B0AA00D1CC84 /* LoadFeedFromRemoteUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8A427F2A29B0AA00D1CC84 /* LoadFeedFromRemoteUseCaseTests.swift */; };
 		ACB6FCBC2ABA54C7007E4953 /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC8A425A2A295E4200D1CC84 /* EssentialFeed.framework */; };
 		ACB6FCBD2ABA54C7007E4953 /* EssentialFeed.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AC8A425A2A295E4200D1CC84 /* EssentialFeed.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		ACB6FCC12ABA55B3007E4953 /* XCTTestCase+MemoryTrackingHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACE5CB4D2A3A888500F1A788 /* XCTTestCase+MemoryTrackingHelper.swift */; };
 		ACC291632AB8FD9200CFE54D /* EssentialFeediOS.docc in Sources */ = {isa = PBXBuildFile; fileRef = ACC291622AB8FD9200CFE54D /* EssentialFeediOS.docc */; };
 		ACC291692AB8FD9200CFE54D /* EssentialFeediOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ACC2915F2AB8FD9200CFE54D /* EssentialFeediOS.framework */; };
 		ACC2917A2ABA500600CFE54D /* FeedViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACC291792ABA500600CFE54D /* FeedViewControllerTests.swift */; };
@@ -702,6 +703,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ACC2917A2ABA500600CFE54D /* FeedViewControllerTests.swift in Sources */,
+				ACB6FCC12ABA55B3007E4953 /* XCTTestCase+MemoryTrackingHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		AC8A42752A295F1300D1CC84 /* FeedImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8A42742A295F1300D1CC84 /* FeedImage.swift */; };
 		AC8A42772A295F7800D1CC84 /* FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8A42762A295F7800D1CC84 /* FeedLoader.swift */; };
 		AC8A42802A29B0AA00D1CC84 /* LoadFeedFromRemoteUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8A427F2A29B0AA00D1CC84 /* LoadFeedFromRemoteUseCaseTests.swift */; };
+		ACB6FCBC2ABA54C7007E4953 /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC8A425A2A295E4200D1CC84 /* EssentialFeed.framework */; };
+		ACB6FCBD2ABA54C7007E4953 /* EssentialFeed.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AC8A425A2A295E4200D1CC84 /* EssentialFeed.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		ACC291632AB8FD9200CFE54D /* EssentialFeediOS.docc in Sources */ = {isa = PBXBuildFile; fileRef = ACC291622AB8FD9200CFE54D /* EssentialFeediOS.docc */; };
 		ACC291692AB8FD9200CFE54D /* EssentialFeediOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ACC2915F2AB8FD9200CFE54D /* EssentialFeediOS.framework */; };
 		ACC2917A2ABA500600CFE54D /* FeedViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACC291792ABA500600CFE54D /* FeedViewControllerTests.swift */; };
@@ -73,6 +75,13 @@
 			remoteGlobalIDString = AC8A42592A295E4200D1CC84;
 			remoteInfo = EssentialFeed;
 		};
+		ACB6FCBE2ABA54C7007E4953 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AC8A42512A295E4200D1CC84 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AC8A42592A295E4200D1CC84;
+			remoteInfo = EssentialFeed;
+		};
 		ACC2916A2AB8FD9200CFE54D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = AC8A42512A295E4200D1CC84 /* Project object */;
@@ -81,6 +90,20 @@
 			remoteInfo = EssentialFeediOS;
 		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		ACB6FCC02ABA54C7007E4953 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				ACB6FCBD2ABA54C7007E4953 /* EssentialFeed.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		AC255CF42A98119C007D38F0 /* EssentialFeedCacheIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialFeedCacheIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -168,6 +191,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ACB6FCBC2ABA54C7007E4953 /* EssentialFeed.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -255,6 +279,7 @@
 				ACC291602AB8FD9200CFE54D /* EssentialFeediOS */,
 				ACC2916C2AB8FD9200CFE54D /* EssentialFeediOSTests */,
 				AC8A425B2A295E4200D1CC84 /* Products */,
+				ACB6FCBB2ABA54C7007E4953 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -303,6 +328,13 @@
 				AC8A42762A295F7800D1CC84 /* FeedLoader.swift */,
 			);
 			path = "Feed Feature";
+			sourceTree = "<group>";
+		};
+		ACB6FCBB2ABA54C7007E4953 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		ACC291602AB8FD9200CFE54D /* EssentialFeediOS */ = {
@@ -464,10 +496,12 @@
 				ACC2915B2AB8FD9200CFE54D /* Sources */,
 				ACC2915C2AB8FD9200CFE54D /* Frameworks */,
 				ACC2915D2AB8FD9200CFE54D /* Resources */,
+				ACB6FCC02ABA54C7007E4953 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				ACB6FCBF2ABA54C7007E4953 /* PBXTargetDependency */,
 			);
 			name = EssentialFeediOS;
 			productName = EssentialFeediOS;
@@ -688,6 +722,11 @@
 			isa = PBXTargetDependency;
 			target = AC8A42592A295E4200D1CC84 /* EssentialFeed */;
 			targetProxy = AC8A42662A295E4200D1CC84 /* PBXContainerItemProxy */;
+		};
+		ACB6FCBF2ABA54C7007E4953 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = AC8A42592A295E4200D1CC84 /* EssentialFeed */;
+			targetProxy = ACB6FCBE2ABA54C7007E4953 /* PBXContainerItemProxy */;
 		};
 		ACC2916B2AB8FD9200CFE54D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		AC8A42802A29B0AA00D1CC84 /* LoadFeedFromRemoteUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8A427F2A29B0AA00D1CC84 /* LoadFeedFromRemoteUseCaseTests.swift */; };
 		ACC291632AB8FD9200CFE54D /* EssentialFeediOS.docc in Sources */ = {isa = PBXBuildFile; fileRef = ACC291622AB8FD9200CFE54D /* EssentialFeediOS.docc */; };
 		ACC291692AB8FD9200CFE54D /* EssentialFeediOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ACC2915F2AB8FD9200CFE54D /* EssentialFeediOS.framework */; };
+		ACC2917A2ABA500600CFE54D /* FeedViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACC291792ABA500600CFE54D /* FeedViewControllerTests.swift */; };
 		ACE5CB4E2A3A888500F1A788 /* XCTTestCase+MemoryTrackingHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACE5CB4D2A3A888500F1A788 /* XCTTestCase+MemoryTrackingHelper.swift */; };
 		ACF86CEE2A2ABBE600A21D98 /* RemoteFeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF86CED2A2ABBE600A21D98 /* RemoteFeedLoader.swift */; };
 		ACFA8FAC2A743727008F63B4 /* FeedStoreSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACFA8FAB2A743727008F63B4 /* FeedStoreSpecs.swift */; };
@@ -111,12 +112,13 @@
 		AC8A42762A295F7800D1CC84 /* FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoader.swift; sourceTree = "<group>"; };
 		AC8A427E2A29694400D1CC84 /* EssentialFeed.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = EssentialFeed.xctestplan; sourceTree = "<group>"; };
 		AC8A427F2A29B0AA00D1CC84 /* LoadFeedFromRemoteUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadFeedFromRemoteUseCaseTests.swift; sourceTree = "<group>"; };
+		ACB6FCBA2ABA519F007E4953 /* EssentialFeediOSTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = file; path = EssentialFeediOSTests.xctestplan; sourceTree = SOURCE_ROOT; };
 		ACC2915F2AB8FD9200CFE54D /* EssentialFeediOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = EssentialFeediOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ACC291622AB8FD9200CFE54D /* EssentialFeediOS.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = EssentialFeediOS.docc; sourceTree = "<group>"; };
 		ACC291682AB8FD9200CFE54D /* EssentialFeediOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialFeediOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		ACC291762AB8FE4500CFE54D /* EssentialFeediOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = EssentialFeediOS.xctestplan; sourceTree = "<group>"; };
 		ACC291772AB902DC00CFE54D /* CI_macOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = CI_macOS.xctestplan; sourceTree = "<group>"; };
-		ACC291782AB906D600CFE54D /* CI_iOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = file; path = CI_iOS.xctestplan; sourceTree = SOURCE_ROOT; };
+		ACC291782AB906D600CFE54D /* CI_iOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = CI_iOS.xctestplan; sourceTree = SOURCE_ROOT; };
+		ACC291792ABA500600CFE54D /* FeedViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedViewControllerTests.swift; sourceTree = "<group>"; };
 		ACE5CB4D2A3A888500F1A788 /* XCTTestCase+MemoryTrackingHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTTestCase+MemoryTrackingHelper.swift"; sourceTree = "<group>"; };
 		ACF86CED2A2ABBE600A21D98 /* RemoteFeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeedLoader.swift; sourceTree = "<group>"; };
 		ACFA8FAB2A743727008F63B4 /* FeedStoreSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedStoreSpecs.swift; sourceTree = "<group>"; };
@@ -314,7 +316,8 @@
 		ACC2916C2AB8FD9200CFE54D /* EssentialFeediOSTests */ = {
 			isa = PBXGroup;
 			children = (
-				ACC291762AB8FE4500CFE54D /* EssentialFeediOS.xctestplan */,
+				ACB6FCBA2ABA519F007E4953 /* EssentialFeediOSTests.xctestplan */,
+				ACC291792ABA500600CFE54D /* FeedViewControllerTests.swift */,
 			);
 			path = EssentialFeediOSTests;
 			sourceTree = "<group>";
@@ -516,6 +519,7 @@
 					};
 					ACC291672AB8FD9200CFE54D = {
 						CreatedOnToolsVersion = 14.3.1;
+						LastSwiftMigration = 1430;
 					};
 				};
 			};
@@ -663,6 +667,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ACC2917A2ABA500600CFE54D /* FeedViewControllerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1083,6 +1088,7 @@
 		ACC291722AB8FD9200CFE54D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = WK3TD8MH9H;
@@ -1096,6 +1102,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1104,6 +1111,7 @@
 		ACC291732AB8FD9200CFE54D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = WK3TD8MH9H;

--- a/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		AC3F86A22A70911E00BA8497 /* FeedCacheTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC3F86A12A70911E00BA8497 /* FeedCacheTestHelpers.swift */; };
 		AC3F86A42A7091F100BA8497 /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC3F86A32A7091F100BA8497 /* SharedTestHelpers.swift */; };
 		AC3F86A62A70DBFC00BA8497 /* FeedCachePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC3F86A52A70DBFC00BA8497 /* FeedCachePolicy.swift */; };
+		AC50B6C12ABA61800013E78B /* FeedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC50B6C02ABA61800013E78B /* FeedViewController.swift */; };
 		AC5327282A3A9E1400C127BB /* URLSessionHTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC5327272A3A9E1400C127BB /* URLSessionHTTPClient.swift */; };
 		AC5327302A3B859300C127BB /* EssentialFeedAPIEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC53272F2A3B859300C127BB /* EssentialFeedAPIEndToEndTests.swift */; };
 		AC5327312A3B859300C127BB /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC8A425A2A295E4200D1CC84 /* EssentialFeed.framework */; };
@@ -121,6 +122,7 @@
 		AC3F86A12A70911E00BA8497 /* FeedCacheTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCacheTestHelpers.swift; sourceTree = "<group>"; };
 		AC3F86A32A7091F100BA8497 /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
 		AC3F86A52A70DBFC00BA8497 /* FeedCachePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCachePolicy.swift; sourceTree = "<group>"; };
+		AC50B6C02ABA61800013E78B /* FeedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedViewController.swift; sourceTree = "<group>"; };
 		AC5327272A3A9E1400C127BB /* URLSessionHTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionHTTPClient.swift; sourceTree = "<group>"; };
 		AC53272D2A3B859300C127BB /* EssentialFeedAPIEndToEndTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialFeedAPIEndToEndTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC53272F2A3B859300C127BB /* EssentialFeedAPIEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EssentialFeedAPIEndToEndTests.swift; sourceTree = "<group>"; };
@@ -136,7 +138,7 @@
 		AC8A42762A295F7800D1CC84 /* FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoader.swift; sourceTree = "<group>"; };
 		AC8A427E2A29694400D1CC84 /* EssentialFeed.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = EssentialFeed.xctestplan; sourceTree = "<group>"; };
 		AC8A427F2A29B0AA00D1CC84 /* LoadFeedFromRemoteUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadFeedFromRemoteUseCaseTests.swift; sourceTree = "<group>"; };
-		ACB6FCBA2ABA519F007E4953 /* EssentialFeediOSTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = file; path = EssentialFeediOSTests.xctestplan; sourceTree = SOURCE_ROOT; };
+		ACB6FCBA2ABA519F007E4953 /* EssentialFeediOSTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = EssentialFeediOSTests.xctestplan; sourceTree = SOURCE_ROOT; };
 		ACC2915F2AB8FD9200CFE54D /* EssentialFeediOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = EssentialFeediOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ACC291622AB8FD9200CFE54D /* EssentialFeediOS.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = EssentialFeediOS.docc; sourceTree = "<group>"; };
 		ACC291682AB8FD9200CFE54D /* EssentialFeediOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialFeediOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -342,6 +344,7 @@
 			isa = PBXGroup;
 			children = (
 				ACC291622AB8FD9200CFE54D /* EssentialFeediOS.docc */,
+				AC50B6C02ABA61800013E78B /* FeedViewController.swift */,
 			);
 			path = EssentialFeediOS;
 			sourceTree = "<group>";
@@ -694,6 +697,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AC50B6C12ABA61800013E78B /* FeedViewController.swift in Sources */,
 				ACC291632AB8FD9200CFE54D /* EssentialFeediOS.docc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1129,6 +1133,7 @@
 		ACC291722AB8FD9200CFE54D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1152,6 +1157,7 @@
 		ACC291732AB8FD9200CFE54D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/EssentialFeed.xcodeproj/xcshareddata/xcschemes/EssentialFeediOSTests.xcscheme
+++ b/EssentialFeed.xcodeproj/xcshareddata/xcschemes/EssentialFeediOSTests.xcscheme
@@ -5,22 +5,6 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
-      <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "ACC2915E2AB8FD9200CFE54D"
-               BuildableName = "EssentialFeediOS.framework"
-               BlueprintName = "EssentialFeediOS"
-               ReferencedContainer = "container:EssentialFeed.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
@@ -64,15 +48,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "ACC2915E2AB8FD9200CFE54D"
-            BuildableName = "EssentialFeediOS.framework"
-            BlueprintName = "EssentialFeediOS"
-            ReferencedContainer = "container:EssentialFeed.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/EssentialFeed.xcodeproj/xcuserdata/wiiliamperegoy.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/EssentialFeed.xcodeproj/xcuserdata/wiiliamperegoy.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -34,6 +34,11 @@
 			<key>orderHint</key>
 			<integer>5</integer>
 		</dict>
+		<key>EssentialFeediOSTests.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>6</integer>
+		</dict>
 	</dict>
 	<key>SuppressBuildableAutocreation</key>
 	<dict>

--- a/EssentialFeediOS/FeedViewController.swift
+++ b/EssentialFeediOS/FeedViewController.swift
@@ -1,0 +1,29 @@
+//  Created by Wiiliam Peregoy on 9/19/23
+
+import UIKit
+import EssentialFeed
+
+final public class FeedViewController: UITableViewController {
+    private var loader: FeedLoader?
+    
+    public convenience init(loader: FeedLoader) {
+        self.init()
+        
+        self.loader = loader
+    }
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        refreshControl = UIRefreshControl()
+        refreshControl?.addTarget(self, action: #selector(load), for: .valueChanged)
+        load()
+    }
+    
+    @objc private func load() {
+        refreshControl?.beginRefreshing()
+        loader?.load { [weak self] _ in
+            self?.refreshControl?.endRefreshing()
+        }
+    }
+}

--- a/EssentialFeediOSTests.xctestplan
+++ b/EssentialFeediOSTests.xctestplan
@@ -1,7 +1,7 @@
 {
   "configurations" : [
     {
-      "id" : "96DAA969-DCF9-4B0C-9042-1C15A411DB2E",
+      "id" : "EF2DAFB7-2660-4765-9342-03CEFA95084E",
       "name" : "Test Scheme Action",
       "options" : {
 
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : false,
     "testExecutionOrdering" : "random"
   },
   "testTargets" : [

--- a/EssentialFeediOSTests/FeedViewControllerTests.swift
+++ b/EssentialFeediOSTests/FeedViewControllerTests.swift
@@ -23,7 +23,9 @@ final class FeedViewController: UITableViewController {
     }
     
     @objc private func load() {
-        loader?.load { _ in }
+        loader?.load { [weak self] _ in
+            self?.refreshControl?.endRefreshing()
+        }
     }
 }
 
@@ -61,6 +63,14 @@ final class FeedViewControllerTests: XCTestCase {
         XCTAssertEqual(sut.refreshControl?.isRefreshing, true)
     }
     
+    func test_viewDidLoad_hidesIndicatorOnLoaderCompletion() {
+        let (sut, loader) = makeSUT()
+        
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading()
+        
+        XCTAssertEqual(sut.refreshControl?.isRefreshing, false)
+    }
     // MARK: - Helpers
     
     private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedViewController, loader: LoaderSpy) {
@@ -72,11 +82,17 @@ final class FeedViewControllerTests: XCTestCase {
     }
     
     class LoaderSpy: FeedLoader {
-        private(set) var loadCallCount = 0
+        private var completions = [(FeedLoader.Result) -> Void]()
+        var loadCallCount: Int {
+            completions.count
+        }
 
         func load(completion: @escaping (FeedLoader.Result) -> Void) {
-            loadCallCount += 1
-
+            completions.append(completion)
+        }
+        
+        func completeFeedLoading() {
+            completions[0](.success([]))
         }
     }
 }

--- a/EssentialFeediOSTests/FeedViewControllerTests.swift
+++ b/EssentialFeediOSTests/FeedViewControllerTests.swift
@@ -18,6 +18,7 @@ final class FeedViewController: UITableViewController {
         
         refreshControl = UIRefreshControl()
         refreshControl?.addTarget(self, action: #selector(load), for: .valueChanged)
+        refreshControl?.beginRefreshing()
         load()
     }
     
@@ -51,6 +52,13 @@ final class FeedViewControllerTests: XCTestCase {
         
         sut.refreshControl?.simulatePullToRefresh()
         XCTAssertEqual(loader.loadCallCount, 3)
+    }
+    
+    func test_viewDidLoad_showsLoadingIndicator() {
+        let (sut, _) = makeSUT()
+        sut.loadViewIfNeeded()
+        
+        XCTAssertEqual(sut.refreshControl?.isRefreshing, true)
     }
     
     // MARK: - Helpers

--- a/EssentialFeediOSTests/FeedViewControllerTests.swift
+++ b/EssentialFeediOSTests/FeedViewControllerTests.swift
@@ -34,32 +34,32 @@ final class FeedViewControllerTests: XCTestCase {
     func test_loadFeedActions_requestFeedFromLoader() {
         let (sut, loader) = makeSUT()
         
-        XCTAssertEqual(loader.loadCallCount, 0)
+        XCTAssertEqual(loader.loadCallCount, 0, "Expected no loading requests before view is loaded")
 
         sut.loadViewIfNeeded()
-        XCTAssertEqual(loader.loadCallCount, 1)
-        
+        XCTAssertEqual(loader.loadCallCount, 1, "Expected a loading request once view is loaded")
+
         sut.simulateUserInitiatedFeedReload()
-        XCTAssertEqual(loader.loadCallCount, 2)
-        
+        XCTAssertEqual(loader.loadCallCount, 2, "Expected another loading request once user initiates a reload")
+
         sut.simulateUserInitiatedFeedReload()
-        XCTAssertEqual(loader.loadCallCount, 3)
+        XCTAssertEqual(loader.loadCallCount, 3, "Expected yet another loading request once user initiates another reload")
     }
     
     func test_loadingFeedIndicator_isVisibleWhenLoadingFeed() {
         let (sut, loader) = makeSUT()
         
         sut.loadViewIfNeeded()
-        XCTAssertEqual(sut.isShowingLoadingIndicator, true)
-        
+        XCTAssertTrue(sut.isShowingLoadingIndicator, "Expected loading indicator once view is loaded")
+
         loader.completeFeedLoading(at: 0)
-        XCTAssertEqual(sut.isShowingLoadingIndicator, false)
+        XCTAssertFalse(sut.isShowingLoadingIndicator, "Expected no loading indicator once loading is completed")
 
         sut.simulateUserInitiatedFeedReload()
-        XCTAssertEqual(sut.isShowingLoadingIndicator, true)
- 
+        XCTAssertTrue(sut.isShowingLoadingIndicator, "Expected loading indicator once user initiates a reload")
+
         loader.completeFeedLoading(at: 1)
-        XCTAssertEqual(sut.isShowingLoadingIndicator, false)
+        XCTAssertFalse(sut.isShowingLoadingIndicator, "Expected no loading indicator once user initiated loading is completed")
     }
     
     // MARK: - Helpers

--- a/EssentialFeediOSTests/FeedViewControllerTests.swift
+++ b/EssentialFeediOSTests/FeedViewControllerTests.swift
@@ -18,11 +18,11 @@ final class FeedViewController: UITableViewController {
         
         refreshControl = UIRefreshControl()
         refreshControl?.addTarget(self, action: #selector(load), for: .valueChanged)
-        refreshControl?.beginRefreshing()
         load()
     }
     
     @objc private func load() {
+        refreshControl?.beginRefreshing()
         loader?.load { [weak self] _ in
             self?.refreshControl?.endRefreshing()
         }
@@ -31,23 +31,13 @@ final class FeedViewController: UITableViewController {
 
 final class FeedViewControllerTests: XCTestCase {
     
-    func test_init_doesNotLoadFeed() {
-        let (_, loader) = makeSUT()
+    func test_loadFeedActions_requestFeedFromLoader() {
+        let (sut, loader) = makeSUT()
         
         XCTAssertEqual(loader.loadCallCount, 0)
-    }
-    
-    func test_viewDidLoad_loadsFeed() {
-        let (sut, loader) = makeSUT()
 
         sut.loadViewIfNeeded()
-        
         XCTAssertEqual(loader.loadCallCount, 1)
-    }
-    
-    func test_userInitiatedReload_loadsFeed() {
-        let (sut, loader) = makeSUT()
-        sut.loadViewIfNeeded()
         
         sut.simulateUserInitiatedFeedReload()
         XCTAssertEqual(loader.loadCallCount, 2)
@@ -56,36 +46,19 @@ final class FeedViewControllerTests: XCTestCase {
         XCTAssertEqual(loader.loadCallCount, 3)
     }
     
-    func test_viewDidLoad_showsLoadingIndicator() {
-        let (sut, _) = makeSUT()
-        sut.loadViewIfNeeded()
-        
-        XCTAssertEqual(sut.isShowingLoadingIndicator, true)
-    }
-    
-    func test_viewDidLoad_hidesIndicatorOnLoaderCompletion() {
+    func test_loadingFeedIndicator_isVisibleWhenLoadingFeed() {
         let (sut, loader) = makeSUT()
         
         sut.loadViewIfNeeded()
-        loader.completeFeedLoading()
+        XCTAssertEqual(sut.isShowingLoadingIndicator, true)
         
+        loader.completeFeedLoading(at: 0)
         XCTAssertEqual(sut.isShowingLoadingIndicator, false)
-    }
-    
-    func test_userInitiatedReload_showsLoadingIndicator() {
-        let (sut, _) = makeSUT()
-        
-        sut.simulateUserInitiatedFeedReload()
 
+        sut.simulateUserInitiatedFeedReload()
         XCTAssertEqual(sut.isShowingLoadingIndicator, true)
-    }
-    
-    func test_userInitiatedReload_hidesIndicatorOnLoaderCompletion() {
-        let (sut, loader) = makeSUT()
-
-        sut.simulateUserInitiatedFeedReload()
-        loader.completeFeedLoading()
-
+ 
+        loader.completeFeedLoading(at: 1)
         XCTAssertEqual(sut.isShowingLoadingIndicator, false)
     }
     
@@ -109,8 +82,8 @@ final class FeedViewControllerTests: XCTestCase {
             completions.append(completion)
         }
         
-        func completeFeedLoading() {
-            completions[0](.success([]))
+        func completeFeedLoading(at index: Int) {
+            completions[index](.success([]))
         }
     }
 }

--- a/EssentialFeediOSTests/FeedViewControllerTests.swift
+++ b/EssentialFeediOSTests/FeedViewControllerTests.swift
@@ -45,14 +45,14 @@ final class FeedViewControllerTests: XCTestCase {
         XCTAssertEqual(loader.loadCallCount, 1)
     }
     
-    func test_pullToRefresh_loadsFeed() {
+    func test_userInitiatedReload_loadsFeed() {
         let (sut, loader) = makeSUT()
         sut.loadViewIfNeeded()
         
-        sut.refreshControl?.simulatePullToRefresh()
+        sut.simulateUserInitiatedFeedReload()
         XCTAssertEqual(loader.loadCallCount, 2)
         
-        sut.refreshControl?.simulatePullToRefresh()
+        sut.simulateUserInitiatedFeedReload()
         XCTAssertEqual(loader.loadCallCount, 3)
     }
     
@@ -60,7 +60,7 @@ final class FeedViewControllerTests: XCTestCase {
         let (sut, _) = makeSUT()
         sut.loadViewIfNeeded()
         
-        XCTAssertEqual(sut.refreshControl?.isRefreshing, true)
+        XCTAssertEqual(sut.isShowingLoadingIndicator, true)
     }
     
     func test_viewDidLoad_hidesIndicatorOnLoaderCompletion() {
@@ -69,24 +69,24 @@ final class FeedViewControllerTests: XCTestCase {
         sut.loadViewIfNeeded()
         loader.completeFeedLoading()
         
-        XCTAssertEqual(sut.refreshControl?.isRefreshing, false)
+        XCTAssertEqual(sut.isShowingLoadingIndicator, false)
     }
     
-    func test_pullToRefresh_showsLoadingIndicator() {
+    func test_userInitiatedReload_showsLoadingIndicator() {
         let (sut, _) = makeSUT()
         
-        sut.refreshControl?.simulatePullToRefresh()
+        sut.simulateUserInitiatedFeedReload()
 
-        XCTAssertEqual(sut.refreshControl?.isRefreshing, true)
+        XCTAssertEqual(sut.isShowingLoadingIndicator, true)
     }
     
-    func test_pullToRefresh_hidesIndicatorOnLoaderCompletion() {
+    func test_userInitiatedReload_hidesIndicatorOnLoaderCompletion() {
         let (sut, loader) = makeSUT()
 
-        sut.refreshControl?.simulatePullToRefresh()
+        sut.simulateUserInitiatedFeedReload()
         loader.completeFeedLoading()
 
-        XCTAssertEqual(sut.refreshControl?.isRefreshing, false)
+        XCTAssertEqual(sut.isShowingLoadingIndicator, false)
     }
     
     // MARK: - Helpers
@@ -112,6 +112,16 @@ final class FeedViewControllerTests: XCTestCase {
         func completeFeedLoading() {
             completions[0](.success([]))
         }
+    }
+}
+
+private extension FeedViewController {
+    func simulateUserInitiatedFeedReload() {
+        refreshControl?.simulatePullToRefresh()
+    }
+    
+    var isShowingLoadingIndicator: Bool {
+        refreshControl?.isRefreshing == true
     }
     
 }

--- a/EssentialFeediOSTests/FeedViewControllerTests.swift
+++ b/EssentialFeediOSTests/FeedViewControllerTests.swift
@@ -2,29 +2,25 @@
 
 import XCTest
 
+final class FeedViewController {
+    init(loader: FeedViewControllerTests.LoaderSpy) {
+        
+    }
+}
+
 final class FeedViewControllerTests: XCTestCase {
-
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    
+    func test_init_doesNotLoadFeed() {
+        let loader = LoaderSpy()
+        let sut = FeedViewController(loader: loader)
+        
+        XCTAssertEqual(loader.loadCallCount, 0)
     }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
+    
+    // MARK: - Helpers
+    
+    class LoaderSpy {
+        private(set) var loadCallCount = 0
     }
 
 }

--- a/EssentialFeediOSTests/FeedViewControllerTests.swift
+++ b/EssentialFeediOSTests/FeedViewControllerTests.swift
@@ -1,11 +1,13 @@
 //  Created by Wiiliam Peregoy on 9/19/23
 
 import XCTest
+import UIKit
+import EssentialFeed
 
 final class FeedViewController: UIViewController {
-    private var loader: FeedViewControllerTests.LoaderSpy?
+    private var loader: FeedLoader?
     
-    convenience init(loader: FeedViewControllerTests.LoaderSpy) {
+    convenience init(loader: FeedLoader) {
         self.init()
         
         self.loader = loader
@@ -14,7 +16,9 @@ final class FeedViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        loader?.load()
+        loader?.load { _ in
+            
+        }
     }
 }
 
@@ -38,11 +42,12 @@ final class FeedViewControllerTests: XCTestCase {
     
     // MARK: - Helpers
     
-    class LoaderSpy {
+    class LoaderSpy: FeedLoader {
         private(set) var loadCallCount = 0
-        
-        func load() {
+
+        func load(completion: @escaping (FeedLoader.Result) -> Void) {
             loadCallCount += 1
+
         }
     }
 

--- a/EssentialFeediOSTests/FeedViewControllerTests.swift
+++ b/EssentialFeediOSTests/FeedViewControllerTests.swift
@@ -4,7 +4,7 @@ import XCTest
 import UIKit
 import EssentialFeed
 
-final class FeedViewController: UIViewController {
+final class FeedViewController: UITableViewController {
     private var loader: FeedLoader?
     
     convenience init(loader: FeedLoader) {
@@ -16,9 +16,13 @@ final class FeedViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        loader?.load { _ in
-            
-        }
+        refreshControl = UIRefreshControl()
+        refreshControl?.addTarget(self, action: #selector(load), for: .valueChanged)
+        load()
+    }
+    
+    @objc private func load() {
+        loader?.load { _ in }
     }
 }
 
@@ -36,6 +40,19 @@ final class FeedViewControllerTests: XCTestCase {
         sut.loadViewIfNeeded()
         
         XCTAssertEqual(loader.loadCallCount, 1)
+    }
+    
+    func test_pullToRefresh_loadsFeed() {
+        let (sut, loader) = makeSUT()
+        sut.loadViewIfNeeded()
+        
+        sut.refreshControl?.allTargets.forEach { target in
+            sut.refreshControl?.actions(forTarget: target, forControlEvent: .valueChanged)?.forEach {
+                (target as NSObject).perform(Selector($0))
+            }
+        }
+        
+        XCTAssertEqual(loader.loadCallCount, 2)
     }
     
     // MARK: - Helpers
@@ -56,6 +73,5 @@ final class FeedViewControllerTests: XCTestCase {
 
         }
     }
-    
-
 }
+

--- a/EssentialFeediOSTests/FeedViewControllerTests.swift
+++ b/EssentialFeediOSTests/FeedViewControllerTests.swift
@@ -2,9 +2,19 @@
 
 import XCTest
 
-final class FeedViewController {
-    init(loader: FeedViewControllerTests.LoaderSpy) {
+final class FeedViewController: UIViewController {
+    private var loader: FeedViewControllerTests.LoaderSpy?
+    
+    convenience init(loader: FeedViewControllerTests.LoaderSpy) {
+        self.init()
         
+        self.loader = loader
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        loader?.load()
     }
 }
 
@@ -12,15 +22,28 @@ final class FeedViewControllerTests: XCTestCase {
     
     func test_init_doesNotLoadFeed() {
         let loader = LoaderSpy()
-        let sut = FeedViewController(loader: loader)
+        _ = FeedViewController(loader: loader)
         
         XCTAssertEqual(loader.loadCallCount, 0)
+    }
+    
+    func test_viewDidLoad_loadsFeed() {
+        let loader = LoaderSpy()
+        let sut = FeedViewController(loader: loader)
+        
+        sut.loadViewIfNeeded()
+        
+        XCTAssertEqual(loader.loadCallCount, 1)
     }
     
     // MARK: - Helpers
     
     class LoaderSpy {
         private(set) var loadCallCount = 0
+        
+        func load() {
+            loadCallCount += 1
+        }
     }
 
 }

--- a/EssentialFeediOSTests/FeedViewControllerTests.swift
+++ b/EssentialFeediOSTests/FeedViewControllerTests.swift
@@ -71,6 +71,24 @@ final class FeedViewControllerTests: XCTestCase {
         
         XCTAssertEqual(sut.refreshControl?.isRefreshing, false)
     }
+    
+    func test_pullToRefresh_showsLoadingIndicator() {
+        let (sut, _) = makeSUT()
+        
+        sut.refreshControl?.simulatePullToRefresh()
+
+        XCTAssertEqual(sut.refreshControl?.isRefreshing, true)
+    }
+    
+    func test_pullToRefresh_hidesIndicatorOnLoaderCompletion() {
+        let (sut, loader) = makeSUT()
+
+        sut.refreshControl?.simulatePullToRefresh()
+        loader.completeFeedLoading()
+
+        XCTAssertEqual(sut.refreshControl?.isRefreshing, false)
+    }
+    
     // MARK: - Helpers
     
     private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedViewController, loader: LoaderSpy) {
@@ -95,6 +113,7 @@ final class FeedViewControllerTests: XCTestCase {
             completions[0](.success([]))
         }
     }
+    
 }
 
 private extension UIRefreshControl {

--- a/EssentialFeediOSTests/FeedViewControllerTests.swift
+++ b/EssentialFeediOSTests/FeedViewControllerTests.swift
@@ -3,31 +3,7 @@
 import XCTest
 import UIKit
 import EssentialFeed
-
-final class FeedViewController: UITableViewController {
-    private var loader: FeedLoader?
-    
-    convenience init(loader: FeedLoader) {
-        self.init()
-        
-        self.loader = loader
-    }
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        refreshControl = UIRefreshControl()
-        refreshControl?.addTarget(self, action: #selector(load), for: .valueChanged)
-        load()
-    }
-    
-    @objc private func load() {
-        refreshControl?.beginRefreshing()
-        loader?.load { [weak self] _ in
-            self?.refreshControl?.endRefreshing()
-        }
-    }
-}
+import EssentialFeediOS
 
 final class FeedViewControllerTests: XCTestCase {
     

--- a/EssentialFeediOSTests/FeedViewControllerTests.swift
+++ b/EssentialFeediOSTests/FeedViewControllerTests.swift
@@ -46,13 +46,11 @@ final class FeedViewControllerTests: XCTestCase {
         let (sut, loader) = makeSUT()
         sut.loadViewIfNeeded()
         
-        sut.refreshControl?.allTargets.forEach { target in
-            sut.refreshControl?.actions(forTarget: target, forControlEvent: .valueChanged)?.forEach {
-                (target as NSObject).perform(Selector($0))
-            }
-        }
-        
+        sut.refreshControl?.simulatePullToRefresh()
         XCTAssertEqual(loader.loadCallCount, 2)
+        
+        sut.refreshControl?.simulatePullToRefresh()
+        XCTAssertEqual(loader.loadCallCount, 3)
     }
     
     // MARK: - Helpers
@@ -75,3 +73,12 @@ final class FeedViewControllerTests: XCTestCase {
     }
 }
 
+private extension UIRefreshControl {
+    func simulatePullToRefresh() {
+        allTargets.forEach { target in
+            actions(forTarget: target, forControlEvent: .valueChanged)?.forEach {
+                (target as NSObject).perform(Selector($0))
+            }
+        }
+    }
+}

--- a/EssentialFeediOSTests/FeedViewControllerTests.swift
+++ b/EssentialFeediOSTests/FeedViewControllerTests.swift
@@ -1,0 +1,30 @@
+//  Created by Wiiliam Peregoy on 9/19/23
+
+import XCTest
+
+final class FeedViewControllerTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/EssentialFeediOSTests/FeedViewControllerTests.swift
+++ b/EssentialFeediOSTests/FeedViewControllerTests.swift
@@ -25,22 +25,28 @@ final class FeedViewController: UIViewController {
 final class FeedViewControllerTests: XCTestCase {
     
     func test_init_doesNotLoadFeed() {
-        let loader = LoaderSpy()
-        _ = FeedViewController(loader: loader)
+        let (_, loader) = makeSUT()
         
         XCTAssertEqual(loader.loadCallCount, 0)
     }
     
     func test_viewDidLoad_loadsFeed() {
-        let loader = LoaderSpy()
-        let sut = FeedViewController(loader: loader)
-        
+        let (sut, loader) = makeSUT()
+
         sut.loadViewIfNeeded()
         
         XCTAssertEqual(loader.loadCallCount, 1)
     }
     
     // MARK: - Helpers
+    
+    private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedViewController, loader: LoaderSpy) {
+        let loader = LoaderSpy()
+        let sut = FeedViewController(loader: loader)
+        trackForMemoryLeaks(loader, file: file, line: line)
+        trackForMemoryLeaks(sut, file: file, line: line)
+        return (sut, loader)
+    }
     
     class LoaderSpy: FeedLoader {
         private(set) var loadCallCount = 0
@@ -50,5 +56,6 @@ final class FeedViewControllerTests: XCTestCase {
 
         }
     }
+    
 
 }

--- a/Prototype/Prototype/Base.lproj/Main.storyboard
+++ b/Prototype/Prototype/Base.lproj/Main.storyboard
@@ -108,6 +108,7 @@
                                 </tableViewCellContentView>
                                 <connections>
                                     <outlet property="descriptionLabel" destination="ZxF-T8-Q1g" id="p6p-2K-fGI"/>
+                                    <outlet property="feedImageContainer" destination="bK3-u5-3le" id="B24-yQ-1Ut"/>
                                     <outlet property="feedImageView" destination="YHv-tV-6Bu" id="yGu-Mg-4fD"/>
                                     <outlet property="locationContainer" destination="v37-x4-Exl" id="VbR-H6-pua"/>
                                     <outlet property="locationLabel" destination="zto-y0-KfA" id="Fb1-wo-fJ0"/>

--- a/Prototype/Prototype/Base.lproj/Main.storyboard
+++ b/Prototype/Prototype/Base.lproj/Main.storyboard
@@ -120,6 +120,12 @@
                         </connections>
                     </tableView>
                     <navigationItem key="navigationItem" title="My Feed" id="bFC-vg-n0B"/>
+                    <refreshControl key="refreshControl" opaque="NO" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="Lf0-wl-djx">
+                        <autoresizingMask key="autoresizingMask"/>
+                        <connections>
+                            <action selector="refresh" destination="bp3-zl-qHA" eventType="valueChanged" id="bkl-bl-00S"/>
+                        </connections>
+                    </refreshControl>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="NnS-L0-auo" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Prototype/Prototype/FeedImageCell.swift
+++ b/Prototype/Prototype/FeedImageCell.swift
@@ -5,6 +5,7 @@ import UIKit
 class FeedImageCell: UITableViewCell {
     @IBOutlet private(set) var locationContainer: UIStackView!
     @IBOutlet private(set) var locationLabel: UILabel!
+    @IBOutlet private(set) var feedImageContainer: UIView!
     @IBOutlet private(set) var feedImageView: UIImageView!
     @IBOutlet private(set) var descriptionLabel: UILabel!
     
@@ -12,23 +13,62 @@ class FeedImageCell: UITableViewCell {
         super.awakeFromNib()
         
         feedImageView.alpha = 0
+        feedImageContainer.startShimmering()
     }
     
     override func prepareForReuse() {
         super.prepareForReuse()
         
         feedImageView.alpha = 0
+        feedImageContainer.startShimmering()
+
     }
     
     func fadeIn(_ image: UIImage?) {
         feedImageView.image = image
         
         UIView.animate(
-            withDuration: 0.3,
-            delay: 0.3,
+            withDuration: 0.25,
+            delay: 1.25,
             options: [],
             animations: {
                 self.feedImageView.alpha = 1
+            }, completion: { completed in
+                if completed {
+                    self.feedImageContainer.stopShimmering()
+                }
             })
     }
 }
+
+private extension UIView {
+     private var shimmerAnimationKey: String {
+         return "shimmer"
+     }
+
+     func startShimmering() {
+         let white = UIColor.white.cgColor
+         let alpha = UIColor.white.withAlphaComponent(0.7).cgColor
+         let width = bounds.width
+         let height = bounds.height
+
+         let gradient = CAGradientLayer()
+         gradient.colors = [alpha, white, alpha]
+         gradient.startPoint = CGPoint(x: 0.0, y: 0.4)
+         gradient.endPoint = CGPoint(x: 1.0, y: 0.6)
+         gradient.locations = [0.4, 0.5, 0.6]
+         gradient.frame = CGRect(x: -width, y: 0, width: width*3, height: height)
+         layer.mask = gradient
+
+         let animation = CABasicAnimation(keyPath: #keyPath(CAGradientLayer.locations))
+         animation.fromValue = [0.0, 0.1, 0.2]
+         animation.toValue = [0.8, 0.9, 1.0]
+         animation.duration = 1
+         animation.repeatCount = .infinity
+         gradient.add(animation, forKey: shimmerAnimationKey)
+     }
+
+     func stopShimmering() {
+         layer.mask = nil
+     }
+ }

--- a/Prototype/Prototype/FeedViewController.swift
+++ b/Prototype/Prototype/FeedViewController.swift
@@ -9,7 +9,25 @@ struct FeedImageViewModel {
 }
 
 final class FeedViewController: UITableViewController {
-    let feed = FeedImageViewModel.prototypeFeed
+    private var feed = [FeedImageViewModel]()
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        refresh()
+        tableView.setContentOffset(CGPoint(x: 0, y: -tableView.contentInset.top), animated: false)
+    }
+    
+    @IBAction func refresh() {
+        refreshControl?.beginRefreshing()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            if self.feed.isEmpty {
+                self.feed = FeedImageViewModel.prototypeFeed
+                self.tableView.reloadData()
+            }
+            self.refreshControl?.endRefreshing()
+        }
+    }
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return feed.count


### PR DESCRIPTION
 Load feed automatically when view is presented
 Allow customer to manually reload feed (pull to refresh)
 Show a loading indicator while loading feed