### PR TITLE
Wait for URLProtocol to start loading requests before cancelling the …

### DIFF
--- a/EssentialFeedTests/Feed API/Helpers/URLProtocolStub.swift
+++ b/EssentialFeedTests/Feed API/Helpers/URLProtocolStub.swift
@@ -5,10 +5,7 @@ import Foundation
 class URLProtocolStub: URLProtocol {
     
     private struct Stub {
-        let data: Data?
-        let response: URLResponse?
-        let error: Error?
-        let requestObserver: ((URLRequest) -> Void)?
+        let onStartLoading: (URLProtocolStub) -> Void
     }
     
     private static var _stub: Stub?
@@ -20,15 +17,39 @@ class URLProtocolStub: URLProtocol {
     private static let queue = DispatchQueue(label: "URLProtocolStub.queue")
     
     static func stub(data: Data?, response: URLResponse?, error: Error?) {
-        stub = Stub(data: data, response: response, error: error, requestObserver: nil)
+        stub = Stub(onStartLoading: { urlProtocol in
+            guard let client = urlProtocol.client else { return }
+            
+            if let data {
+                client.urlProtocol(urlProtocol, didLoad: data)
+            }
+            
+            if let response {
+                client.urlProtocol(urlProtocol, didReceive: response, cacheStoragePolicy: .notAllowed)
+            }
+            
+            if let error {
+                client.urlProtocol(urlProtocol, didFailWithError: error)
+            } else {
+                client.urlProtocolDidFinishLoading(urlProtocol)
+            }
+        })
+    }
+    
+    static func observeRequests(observer: @escaping (URLRequest) -> Void) {
+        stub = Stub(onStartLoading: { urlProtocol in
+            urlProtocol.client?.urlProtocolDidFinishLoading(urlProtocol)
+            
+            observer(urlProtocol.request)
+        })
+    }
+    
+    static func onStartLoading(observer: @escaping () -> Void) {
+        stub = Stub(onStartLoading: { _ in observer() })
     }
     
     static func removeStub() {
         stub = nil
-    }
-    
-    static func observeRequests(observer: @escaping (URLRequest) -> Void) {
-        stub = Stub(data: nil, response: nil, error: nil, requestObserver: observer)
     }
     
     override class func canInit(with request: URLRequest) -> Bool {
@@ -40,23 +61,7 @@ class URLProtocolStub: URLProtocol {
     }
     
     override func startLoading() {
-        guard let stub = URLProtocolStub.stub else { return }
-        
-        if let data = stub.data {
-            client?.urlProtocol(self, didLoad: data)
-        }
-        
-        if let response = stub.response {
-            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-        }
-        
-        if let error = stub.error {
-            client?.urlProtocol(self, didFailWithError: error)
-        } else {
-            client?.urlProtocolDidFinishLoading(self)
-        }
-        
-        stub.requestObserver?(request)
+        URLProtocolStub.stub?.onStartLoading(self)
     }
     
     override func stopLoading() {}

--- a/EssentialFeedTests/Feed API/URLSessionHTTPClientTests.swift
+++ b/EssentialFeedTests/Feed API/URLSessionHTTPClientTests.swift
@@ -68,8 +68,11 @@ final class URLSessionHTTPClientTests: XCTestCase {
     }
     
     func test_cancelGetFromURLTask_cancelsURLRequest() {
-        let receivedError = resultErrorFor(taskHandler: { $0.cancel() }) as NSError?
+        var task: HTTPClientTask?
+        URLProtocolStub.onStartLoading { task?.cancel() }
         
+        let receivedError = resultErrorFor(taskHandler: { task = $0 }) as NSError?
+
         XCTAssertEqual(receivedError?.code, URLError.cancelled.rawValue)
     }
     


### PR DESCRIPTION
…URLSessionTasks when running tests to achieve predictable test results and prevent tasks leaking outside the test scope (which could affect other tests).